### PR TITLE
Adds rate limiting to nginx config for all observation sites

### DIFF
--- a/files/nginx_conf_d/default.conf
+++ b/files/nginx_conf_d/default.conf
@@ -1,0 +1,44 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    #charset koi8-r;
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}

--- a/files/nginx_conf_d/rate-limit.conf
+++ b/files/nginx_conf_d/rate-limit.conf
@@ -1,0 +1,2 @@
+limit_req_zone $binary_remote_addr zone=limitbyaddr:10m rate=10r/s;
+limit_req_status 429;

--- a/files/nginx_include/common-site-config-new.conf
+++ b/files/nginx_include/common-site-config-new.conf
@@ -26,6 +26,7 @@ location / {
   include uwsgi_params;
 
   client_max_body_size 50M;
+  include include/rate.conf;
   include include/block_bot.conf;
 
   if ($host ~* "observa(?!(tion(-test|-acc)?\.org)|(do\.org)|(tions\.be))" ) { rewrite ^/(.*)$ http://observation.org/$1 permanent; }

--- a/files/nginx_include/common-site-config-project.conf
+++ b/files/nginx_include/common-site-config-project.conf
@@ -26,6 +26,7 @@ location / {
   include uwsgi_params;
 
   client_max_body_size 50M;
+  include include/rate.conf;
   include include/block_bot.conf;
 
   if ($host ~* "observa(?!(tion(-test|-acc)?\.org)|(do\.org)|(tions\.be))" ) { rewrite ^/(.*)$ http://observation.org/$1 permanent; }

--- a/files/nginx_include/common-site-config.conf
+++ b/files/nginx_include/common-site-config.conf
@@ -25,6 +25,7 @@ location / {
 	client_max_body_size	50M;
 	location ~ ^/(_router)|(_robots)\.php$ { include include/php_long.conf; }
 
+	include include/rate.conf;
 	include include/block_bot.conf;
 	#include include/block_ip.conf; #uncomment for only internal access
 

--- a/files/nginx_include/rate.conf
+++ b/files/nginx_include/rate.conf
@@ -1,0 +1,2 @@
+limit_req zone=limitbyaddr burst=20 delay=5;
+limit_req_log_level warn;

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -57,6 +57,14 @@ class role_waarneming::web (
     notify  => Service['nginx'],
     require => Package['nginx'],
   }
+  
+  # Nginx conf.d files, verbatim
+  file { '/etc/nginx/conf.d':
+    source  => 'puppet:///modules/role_waarneming/nginx_conf_d',
+    recurse => true,
+    notify  => Service['nginx'],
+    require => Package['nginx'],
+  }
 
   # Nginx phppgadmin.conf include config
   file { '/etc/nginx/include/phppgadmin.conf':


### PR DESCRIPTION
By applying this PR rate limiting is added to the observation setups. This will limit the number of requests allowed considerably. Recent activity on the sites was hurt by a few bad actors. The configuration is based on the nginx documentation:

https://www.nginx.com/blog/rate-limiting-nginx/

It is currently active on the acceptance setup which can be used for limited stress testing:

- [ ] Use the apache benchmark tool, to force the 429, for instance `ab -c 100 -n 10000 https://waarneming-acc.nl`
- [x] Use your browser to visit the site at https://waarneming-acc.nl and try to open many tabs for instance, this should not result in a 429
- [ ] Try something clever to get the rate limit to kick in, which could be considered normal usage

**NOTE**

~~To implement the config below, one extra step needs to be added the `rate-limit.conf` should be put in `/etc/nginx/conf.d`. I guess this needs to be changed in the foreman setup. Please implement this first for the test and acceptance servers and after review it can be launched on the production setup.~~ Already fixed in this PR.

Any other suggestion is very much appreciated, fire away!